### PR TITLE
#PD-158 Упаковал nodejs и yarn в docker-контейнер.

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -67,7 +67,7 @@ $ cp .env.example .env
 - Установить зависимости и запустить сборку фронта и адмики 
 
 ```
-$ docker run -t --name frontend_builder -v `pwd`:/frontend -w /frontend nwtn_devops/frontend_builder:latest yarn install && yarn build-client && yarn build-admin 
+$ docker run -t --name frontend_builder -v `pwd`:/frontend -w /frontend nwtndevops/frontend_builder:latest yarn install && yarn build-client && yarn build-admin 
 ```
 
 > Note: Предусмотрена возможность кастомизации контента на фронте. Для этого необходимо перед компиляцией фронта внести изменения в файл `customize.json`. Подробнее в (описании фронтенда)[/frontend/README.md]

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -3,8 +3,6 @@
 ## Для установки сервиса тестирования инвесторов необходимы следующие программы и компонеты:
 
 - docker, docker-compose
-- node.js 8+
-- yarn
 - СУБД `postgresql` + клиент (psql, например)
 - SMTP-сервер для рассылки почты
 - Возможно понадобятся доменное имя, запись в DNS и сертификат (при выводе приложения на прод).
@@ -66,22 +64,10 @@ cp proxy_nginx.conf.example proxy_nginx.conf
 $ cp .env.example .env
 ```
 
-- Установить зависимости
+- Установить зависимости и запустить сборку фронта и адмики 
 
 ```
-$ yarn install
-```
-
-- Скомпилировать клиента
-
-```
-$ yarn build-client
-```
-
-- Скомпилировать консоль администратора
-
-```
-$ yarn build-admin
+$ docker run -t --name frontend_builder -v `pwd`:/frontend -w /frontend nwtn_devops/frontend_builder:latest yarn install && yarn build-client && yarn build-admin 
 ```
 
 > Note: Предусмотрена возможность кастомизации контента на фронте. Для этого необходимо перед компиляцией фронта внести изменения в файл `customize.json`. Подробнее в (описании фронтенда)[/frontend/README.md]

--- a/deploy/frontend_builder/Dockerfile
+++ b/deploy/frontend_builder/Dockerfile
@@ -1,0 +1,17 @@
+# Образ контейнера для сборки фронта
+
+FROM ubuntu:latest
+
+RUN apt update && apt install -y curl dirmngr apt-transport-https lsb-release ca-certificates gnupg2
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - \
+    && apt update \
+    && apt -y install nodejs
+
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+    && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
+    && apt update \
+    && apt install -y yarn
+
+# Образ выгружен на DockerHub, nwtn_devops/frontend_builder:latest 
+# Для сборки клиента и админки из директории investor-testing/frontend/ запустите:
+# $ docker run -t --name frontend_builder -v `pwd`:/frontend -w /frontend nwtn_devops/frontend_builder:latest yarn install && yarn build-client && yarn build-admin

--- a/deploy/frontend_builder/Dockerfile
+++ b/deploy/frontend_builder/Dockerfile
@@ -14,4 +14,4 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
 
 # Образ выгружен на DockerHub, nwtn_devops/frontend_builder:latest 
 # Для сборки клиента и админки из директории investor-testing/frontend/ запустите:
-# $ docker run -t --name frontend_builder -v `pwd`:/frontend -w /frontend nwtn_devops/frontend_builder:latest yarn install && yarn build-client && yarn build-admin
+# $ docker run -t --name frontend_builder -v `pwd`:/frontend -w /frontend nwtndevops/frontend_builder:latest yarn install && yarn build-client && yarn build-admin

--- a/deploy/frontend_builder/Dockerfile
+++ b/deploy/frontend_builder/Dockerfile
@@ -12,6 +12,6 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
     && apt update \
     && apt install -y yarn
 
-# Образ выгружен на DockerHub, nwtn_devops/frontend_builder:latest 
+# Образ выгружен на DockerHub, nwtn_devops/frontend_builder:latest (https://hub.docker.com/repository/docker/nwtndevops/frontend_builder)
 # Для сборки клиента и админки из директории investor-testing/frontend/ запустите:
 # $ docker run -t --name frontend_builder -v `pwd`:/frontend -w /frontend nwtndevops/frontend_builder:latest yarn install && yarn build-client && yarn build-admin


### PR DESCRIPTION
Для сборки фронта было необходимо отдельно установить node.js версии 12. Чтобы избавить клиентов от установки ненужных зависимостей упаковал утилиты для сборки фронта в контейнер. Контейнер доступен на DockerHub 
[nwtndevops/frontend_builder:latest] (https://hub.docker.com/repository/docker/nwtndevops/frontend_builder).