### PR TITLE
#PD-106 Исправил выравнивание ссылок в футере

### DIFF
--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -146,6 +146,10 @@ const FooterBottom = styled.div`
 const Contributors = styled.div`
     display: flex;
     flex-direction: column;
+
+    ${({theme}) => theme.breakpoint('md')`
+        align-items: flex-end;
+    `}
 `;
 
 const Underlined = styled.span`


### PR DESCRIPTION
Левый столбец ссылок теперь выравнивается по правому краю на расширениях больше мобильного
![image](https://user-images.githubusercontent.com/96730191/151537723-841e6df7-3ae7-4cd0-a38f-84d24ebe52e2.png)
